### PR TITLE
Enable impersonation via jupyter_kernel_gateway

### DIFF
--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -113,7 +113,12 @@ class RemoteKernelManager(MappingKernelManager):
             response = yield fetch_kg(
                 self.kernels_endpoint,
                 method='POST',
-                body=json_encode({'name' : kernel_name})
+                body=json_encode({
+                    'name': kernel_name,
+                    'env': {
+                        'KERNEL_USERNAME': KG_HTTP_USER
+                    }
+                })
             )
             kernel = json_decode(response.body)
             kernel_id = kernel['id']


### PR DESCRIPTION
Pass an `env` object as part of the POST body to `/api/kernels`
to jupyter_kernel_gateway. KERNEL_* prefixed environment
variables are white-listed by JKG and can be used to start the
actual Jupyter kernel.

[jupyter/kernel_gateway/services/kernels/handlers.py#L56](https://github.com/jupyter/kernel_gateway/blob/ff7340025885232882ba1e0ea512b155cc2785ad/kernel_gateway/services/kernels/handlers.py#L56)